### PR TITLE
Hotfix demande client (article non trié en haut de la liste)

### DIFF
--- a/app/tools/formater.ts
+++ b/app/tools/formater.ts
@@ -59,7 +59,7 @@ export function sortByCustomSortIndex<T extends { custom_sort_index?: number | n
         const idx =
             typeof raw === "number" && Number.isFinite(raw)
                 ? raw
-                : Number.POSITIVE_INFINITY;
+                : Number.NEGATIVE_INFINITY;
         return { item, idx, originalPosition };
     });
 


### PR DESCRIPTION
This pull request makes a small but important change to the `sortByCustomSortIndex` function in `app/tools/formater.ts`. The default sort index for items without a valid `custom_sort_index` is changed from positive infinity to negative infinity, which will cause these items to appear at the beginning of the sorted list instead of the end.

* Changed the default sort index in `sortByCustomSortIndex` from `Number.POSITIVE_INFINITY` to `Number.NEGATIVE_INFINITY`, so items lacking a valid `custom_sort_index` are sorted to the start of the list.